### PR TITLE
Updaet IClockedDevice::handleClockTick

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -1,13 +1,15 @@
 # Tasks
 
-This is not comprehensive. I'm in the midst of a new-project flurry of doing a million tasks, so this list is going to be missing items for sure. Ranked in terms of priority, from highest to lowest:
+This is not comprehensive. I'm in the midst of a new-project flurry of doing a million tasks, so this list is going to be missing items for sure. Ranked in terms of priority, from highest to lowest priority, this is the set of tasks I'll be working in upcoming contributions:
 
 - Update clock tick handler to include the tick id as a param
 - Add a logger interface, with a stdout implementation
 - Add clang-format
 - Add unit tests
+- Update README
 - Pull in test ROMs (this might change how the logger needs to work, depending on how the validation for the test ROMs work)
 - Add a scanline renderer in opengl
+- Doxygen generation
 - Add a conf file that controls
   - window size
   - controller mappings + hotkeys

--- a/src/emulator/apu/apu.cpp
+++ b/src/emulator/apu/apu.cpp
@@ -1,3 +1,5 @@
+#include <fmt/core.h>
+
 #include "apu.h"
 #include "logger.h"
 
@@ -8,8 +10,13 @@ APU::APU(Logger& logger) : _logger(logger)
 {
 }
 
-void APU::handleClockTick()
+void APU::handleClockTick(std::uint64_t tickNum)
 {
+    _logger.write(
+        LogLevel::trace,
+        fmt::format("handling tickNum: {}", tickNum)
+    );
+
     // TODO
 }
 

--- a/src/emulator/apu/apu.h
+++ b/src/emulator/apu/apu.h
@@ -15,7 +15,7 @@ public:
     APU(Logger& logger);
     ~APU() override = default;
 
-    void handleClockTick() override;
+    void handleClockTick(std::uint64_t tickNum) override;
 };
 
 } // unnes

--- a/src/emulator/clock/clock.cpp
+++ b/src/emulator/clock/clock.cpp
@@ -7,8 +7,7 @@ namespace unnes
 {
 
 Clock::Clock(Logger& logger)
-    : _connectedDevices()
-    , _logger(logger)
+    : _logger(logger)
 {
 }
 
@@ -19,14 +18,14 @@ void Clock::connect(const std::vector<IClockedDevice*>& devices)
 
 std::uint64_t Clock::tick()
 {
-    ++_cycleNum;
+    _totalTicks++;
 
     for (auto& device : _connectedDevices)
     {
-        device->handleClockTick();
+        device->handleClockTick(_totalTicks);
     }
 
-    return _cycleNum;
+    return _totalTicks;
 }
 
 std::uint32_t Clock::getSpeedHz() const

--- a/src/emulator/clock/clock.h
+++ b/src/emulator/clock/clock.h
@@ -10,11 +10,19 @@ namespace unnes
 
 class Logger;
 
+/// @brief An interface for any device connected to the clock (like the CPU or PPU). When a clock tick occurs,
+/// any device implementing this interface that has connected itself to the Clock via
+/// Clock::connect will be notified of the clock tick via its handClockTick implementation.
+///
+/// @see Clock::connect
 struct IClockedDevice
 {
     virtual ~IClockedDevice() = default;
 
-    virtual void handleClockTick() = 0;
+    /// @brief Hardware components react to each cock tick via their implementation of this method.
+    ///
+    /// @param tickNum The exact clock tick number since emulator boot.
+    virtual void handleClockTick(std::uint64_t tickNum) = 0;
 };
 
 class Clock
@@ -22,13 +30,17 @@ class Clock
     /// @note _speedHz isn't const because we want to be able to adjust the speed of emulation
     /// dynamically, based on the user's application settings.
     std::uint32_t _speedHz { ntsc::kSpeedHz };
-    std::uint64_t _cycleNum { 0 };
-    std::vector<IClockedDevice*> _connectedDevices;
+    std::uint64_t _totalTicks { 0 };
+    std::vector<IClockedDevice*> _connectedDevices {};
     Logger& _logger;
 
 public:
     Clock(Logger& logger);
 
+    /// @brief Connects a set of devices to this clock. These devices will be notified on each
+    /// clock tick, via the IClockedDevice::handleClockTick function.
+    ///
+    /// @param devices The devices to connect to this clock instance.
     void connect(const std::vector<IClockedDevice*>& devices);
 
     /// @brief Cycles the clock once.

--- a/src/emulator/cpu/cpu.cpp
+++ b/src/emulator/cpu/cpu.cpp
@@ -1,3 +1,5 @@
+#include <fmt/core.h>
+
 #include "cpu.h"
 #include "logger.h"
 
@@ -9,8 +11,13 @@ CPU::CPU(Logger& logger)
 {
 }
 
-void CPU::handleClockTick()
+void CPU::handleClockTick(std::uint64_t tickNum)
 {
+    _logger.write(
+        LogLevel::trace,
+        fmt::format("handling tickNum: {}", tickNum)
+    );
+
     // TODO
 }
 

--- a/src/emulator/cpu/cpu.h
+++ b/src/emulator/cpu/cpu.h
@@ -13,7 +13,7 @@ public:
     CPU(Logger& logger);
     ~CPU() override = default;
 
-    void handleClockTick() override;
+    void handleClockTick(std::uint64_t tickNum) override;
 
 };
 

--- a/src/emulator/memory/ram.cpp
+++ b/src/emulator/memory/ram.cpp
@@ -1,3 +1,5 @@
+#include <fmt/core.h>
+
 #include "logger.h"
 #include "ram.h"
 
@@ -9,8 +11,13 @@ RAM::RAM(Logger& logger)
 {
 }
 
-void RAM::handleClockTick()
+void RAM::handleClockTick(std::uint64_t tickNum)
 {
+    _logger.write(
+        LogLevel::trace,
+        fmt::format("handling tickNum: {}", tickNum)
+    );
+
     // TODO
 }
 

--- a/src/emulator/memory/ram.h
+++ b/src/emulator/memory/ram.h
@@ -15,7 +15,7 @@ public:
     RAM(Logger& logger);
     ~RAM() override = default;
 
-    void handleClockTick() override;
+    void handleClockTick(std::uint64_t tickNum) override;
 
 };
 

--- a/src/emulator/memory/rom.cpp
+++ b/src/emulator/memory/rom.cpp
@@ -1,3 +1,5 @@
+#include <fmt/core.h>
+
 #include "logger.h"
 #include "rom.h"
 
@@ -9,8 +11,13 @@ ROM::ROM(Logger& logger)
 {
 }
 
-void ROM::handleClockTick()
+void ROM::handleClockTick(std::uint64_t tickNum)
 {
+    _logger.write(
+        LogLevel::trace,
+        fmt::format("handling tickNum: {}", tickNum)
+    );
+
     // TODO
 }
 

--- a/src/emulator/memory/rom.h
+++ b/src/emulator/memory/rom.h
@@ -15,7 +15,7 @@ public:
     ROM(Logger& logger);
     ~ROM() override = default;
 
-    void handleClockTick() override;
+    void handleClockTick(std::uint64_t tickNum) override;
 
 };
 

--- a/src/emulator/ppu/ppu.cpp
+++ b/src/emulator/ppu/ppu.cpp
@@ -1,3 +1,5 @@
+#include <fmt/core.h>
+
 #include "logger.h"
 #include "ppu.h"
 
@@ -9,8 +11,13 @@ PPU::PPU(Logger& logger)
 {
 }
 
-void PPU::handleClockTick()
+void PPU::handleClockTick(std::uint64_t tickNum)
 {
+    _logger.write(
+        LogLevel::trace,
+        fmt::format("handling tickNum: {}", tickNum)
+    );
+
     // TODO
 }
 

--- a/src/emulator/ppu/ppu.h
+++ b/src/emulator/ppu/ppu.h
@@ -15,7 +15,7 @@ public:
     PPU(Logger& logger);
     ~PPU() override = default;
 
-    void handleClockTick() override;
+    void handleClockTick(std::uint64_t tickNum) override;
 
 };
 

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -21,7 +21,7 @@ enum class LogLevel
 class Logger
 {
 private:
-    LogLevel _level = LogLevel::all;
+    LogLevel _level = LogLevel::info;
 
 protected:
     Logger() = default;


### PR DESCRIPTION
Previous the IClockedDevice::handleClockTick interface method wasn't aware of the tick count to which it was reacting. This change plumbs in the tick count, so each clock tick can be uniquely identified.